### PR TITLE
get root hash in hex format

### DIFF
--- a/merkle_tree.js
+++ b/merkle_tree.js
@@ -27,7 +27,7 @@ const merkleTree = new MerkleTree(leafNodes, keccak256, { sortPairs: true});
 // Print out the Entire Merkle Tree.
 const rootHash = merkleTree.getRoot();
 console.log('Whitelist Merkle Tree\n', merkleTree.toString());
-console.log("Root Hash: ", rootHash);
+console.log("Root Hash: ", rootHash.toString('hex')); // get the root hash in hexadecimal format
 
 // ***** ***** ***** ***** ***** ***** ***** ***** // 
 


### PR DESCRIPTION
The curent hash is showing in buffer format, which is not usable in the curent format. It'll will be nice to get the root hash in hexadecimal readable format, which is what will be used in the contract.